### PR TITLE
adding check for if we're local to return localhost

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,12 @@ function getServiceCallHeaders () {
  */
 function getUrl (opts, callback) {
 
+  // if FH_SERVICE_MAP exists, we're in local development
+  if (process.env.FH_SERVICE_MAP) {
+    var port = process.env.FH_PORT || process.env.OPENSHIFT_NODEJS_PORT || 8001;
+    return callback(null, 'http://localhost:' + port);
+  }
+
   function onParse (err, json) {
     if (err) {
       callback(

--- a/test/index.js
+++ b/test/index.js
@@ -96,6 +96,15 @@ describe('fh-instance-url', function () {
       });
     });
 
+    it('Should handle local development', function () {
+      process.env.FH_SERVICE_MAP = true
+      iurl("anything", function (err, url) {
+        assert.equal(err, null);
+        assert.equal(typeof url, 'string');
+        assert.equal( url, 'http://localhost:8001');
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
We now check to see if `process.env.FH_SERVICE_MAP` exists, and if it does return "http://localhost:8001"
