### PR TITLE
Adding local development support

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,14 @@ function getUrl (opts, callback) {
   if (process.env.FH_SERVICE_MAP) {
     var guid = opts.guid || opts;
     var serviceMap = JSON.parse(process.env.FH_SERVICE_MAP);
-    return callback(null, serviceMap[guid]);
+    if (serviceMap[guid]) {
+      return callback(null, serviceMap[guid]);
+    } else {
+      return callback(
+        new Error('No entry found in FH_SERVICE_MAP'),
+        null
+      );
+    }
   }
 
   function onParse (err, json) {

--- a/index.js
+++ b/index.js
@@ -45,8 +45,9 @@ function getUrl (opts, callback) {
 
   // if FH_SERVICE_MAP exists, we're in local development
   if (process.env.FH_SERVICE_MAP) {
-    var port = process.env.FH_PORT || process.env.OPENSHIFT_NODEJS_PORT || 8001;
-    return callback(null, 'http://localhost:' + port);
+    var guid = opts.guid || opts;
+    var serviceMap = JSON.parse(process.env.FH_SERVICE_MAP);
+    return callback(null, serviceMap[guid]);
   }
 
   function onParse (err, json) {

--- a/index.js
+++ b/index.js
@@ -43,6 +43,12 @@ function getServiceCallHeaders () {
  */
 function getUrl (opts, callback) {
 
+  // if FH_SERVICE_MAP exists, we're in local development
+  if (process.env.FH_SERVICE_MAP) {
+    var port = process.env.FH_PORT || process.env.OPENSHIFT_NODEJS_PORT || 8001;
+    return callback(null, 'http://localhost:' + port);
+  }
+
   function onParse (err, json) {
     if (err) {
       callback(

--- a/test/index.js
+++ b/test/index.js
@@ -97,8 +97,10 @@ describe('fh-instance-url', function () {
     });
 
     it('Should handle local development', function () {
-      process.env.FH_SERVICE_MAP = true
-      iurl("anything", function (err, url) {
+      process.env.FH_SERVICE_MAP = JSON.stringify({
+        localtest: 'http://localhost:8001'
+      });
+      iurl('localtest', function (err, url) {
         assert.equal(err, null);
         assert.equal(typeof url, 'string');
         assert.equal( url, 'http://localhost:8001');

--- a/test/index.js
+++ b/test/index.js
@@ -96,6 +96,15 @@ describe('fh-instance-url', function () {
       });
     });
 
+    it('Should handle local development', function () {
+      process.env.FH_SERVICE_MAP = true
+      iurl("anything", function (err, url) {
+        assert.equal(err, null);
+        assert.equal(typeof url, 'string');
+        assert.equal( url, 'http://localhost:8001');
+      });
+    });
+
   });
 
 });

--- a/test/index.js
+++ b/test/index.js
@@ -96,7 +96,7 @@ describe('fh-instance-url', function () {
       });
     });
 
-    it('Should handle local development', function () {
+    it('Should handle local development if a service map entry exists', function () {
       process.env.FH_SERVICE_MAP = JSON.stringify({
         localtest: 'http://localhost:8001'
       });
@@ -104,6 +104,20 @@ describe('fh-instance-url', function () {
         assert.equal(err, null);
         assert.equal(typeof url, 'string');
         assert.equal( url, 'http://localhost:8001');
+      });
+    });
+
+    it('Should handle local development if no service map entry exists', function () {
+      process.env.FH_SERVICE_MAP = JSON.stringify({
+        localtest: 'http://localhost:8001'
+      });
+      iurl('badtest', function (err, url) {
+        assert.notEqual(err, null);
+        assert.equal(
+          err.toString(),
+          'Error: No entry found in FH_SERVICE_MAP'
+        );
+        assert.equal(url, null);
       });
     });
 


### PR DESCRIPTION
Will return a match from FH_SERVICE_MAP if one exists and you are developing locally, or with throw a `No entry found in FH_SERVICE_MAP` error if one doesn't exist
